### PR TITLE
Header en footer responsive

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -138,6 +138,10 @@ header {
         p {
             text-align: center;
         }
+
+        @media screen and (min-width: 800px) {
+            flex-direction: row;
+        }
     }
 
     @view-transition {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -43,7 +43,7 @@
     padding: 0; 
 }
 
-main {
+:global(body) {
     --primary-color: #A675F4;
     --secondary-color:  #ececec;
 	--primary-highlight: #66e5bf;
@@ -55,14 +55,8 @@ main {
     font-family: "Open Sans", serif;
     font-size: 16px; 
 	background-color: var(--primary-color);
-    
-
-}
-
-main {
-
-    background-color: var(--secondary-color);
-    border: #A675F4 20px solid;
+    padding: 1em;
+    margin: 0;
 }
 
 header {
@@ -70,21 +64,33 @@ header {
     color: var(--primary-text);
     border-radius: 0 0 var(--section-radius) var(--section-radius);
     padding: var(--section-padding);
-    margin-left: 15%;
-    position: sticky; 
-    width: 70%;
+    position: fixed;
     top: 0;
+    left: 50%;
+    transform: translateX(-50%); 
     z-index: 99;
-
-    /* Flex */
-    display: flex; 
+    display: flex;
     align-items: center;
-    justify-content: center;
+    justify-content: space-between; 
     gap: 2rem;
+    width: 93%;
+
+    @media screen and (min-width: 800px) {
+        width: 75%;
+        margin: auto;
+    }
 }
 
     .header-logo {
-        width: 30%;
+        width: 5em;
+    }
+
+    .header-logo-hva {
+        display: none;
+
+        @media screen and (min-width: 800px) {
+            display: block;
+        }
     }
 
      .home {
@@ -96,7 +102,7 @@ header {
         border-radius: .5em;
         font-weight: 600;
         transition: .2s ease-in-out;
-        margin: 0 0 1em 0;
+        margin: -.5em 0 0 0;
 
         box-shadow:
             -5px 5px 1px var(--primary-highlight),
@@ -116,25 +122,22 @@ header {
         }
     }
 
-
-
     footer {
-    background-color: var(--primary-color);
-    color: var(--primary-text);
-    border-radius: var(--section-radius) var(--section-radius) 0 0;
-    padding: var(--section-padding);
-    margin-left: 2%;
-    position: sticky; 
-    width: 96%;
-    top: 0;
-    z-index: 99;
+        background-color: var(--primary-color);
+        color: var(--primary-text);
+        border-radius: var(--section-radius) var(--section-radius) 0 0;
+        padding: 3em 1em 1em 1em;
 
-    /* Flex */
-    display: flex; 
-    align-items: center;
-    justify-content: space-between;
-    gap: 2rem;
-    flex-direction: column;
+        /* Flex */
+        display: flex; 
+        align-items: center;
+        justify-content: space-between;
+        gap: 2rem;
+        flex-direction: column;
+
+        p {
+            text-align: center;
+        }
     }
 
     @view-transition {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -23,7 +23,7 @@
 </svelte:head>
 
 <header> 
-	    <a href="/"><img class="header-logo-hva" src="../hva-blank.svg" alt="naar de homepagina" height="50"></a>
+	    <a class="header-logo-hva" href="/"><img src="../hva-blank.svg" alt="naar de homepagina" height="50"></a>
 	    <a href="/"><img class="header-logo" src="../fdnd.png" alt="FDND" width="100" height="50" style="object-fit: contain;"></a>
 	    <a href="https://programma.fdnd.nl/" class="home">Bekijk programma</a>
 </header>
@@ -126,7 +126,7 @@ header {
         background-color: var(--primary-color);
         color: var(--primary-text);
         border-radius: var(--section-radius) var(--section-radius) 0 0;
-        padding: 3em 1em 1em 1em;
+        padding: 3em 0 1em 0em;
 
         /* Flex */
         display: flex; 
@@ -134,6 +134,14 @@ header {
         justify-content: space-between;
         gap: 2rem;
         flex-direction: column;
+        margin: auto;
+
+        width: 93%;
+
+        @media screen and (min-width: 800px) {
+            width: 75%;
+            margin: auto;
+        }
 
         p {
             text-align: center;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -23,8 +23,8 @@
 </svelte:head>
 
 <header> 
-	    <img class="header-logo-hva" src="../hva-blank.svg" alt="naar de homepagina" height="50">
-	    <img class="header-logo" src="../fdnd.png" alt="FDND" width="100" height="50" style="object-fit: contain;">
+	    <a href="/"><img class="header-logo-hva" src="../hva-blank.svg" alt="naar de homepagina" height="50"></a>
+	    <a href="/"><img class="header-logo" src="../fdnd.png" alt="FDND" width="100" height="50" style="object-fit: contain;"></a>
 	    <a href="https://programma.fdnd.nl/" class="home">Bekijk programma</a>
 </header>
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -22,22 +22,19 @@
 	<link rel="icon" href={favicon} />
 </svelte:head>
 
-
-<main>
-	<header> 
-	<img class="header-logo" src="../hva-blank.svg" alt="naar de homepagina" height="50">
-	<img class="header-logo" src="../fdnd.png" alt="FDND" width="100" height="50" style="object-fit: contain;">
-	<a href="https://programma.fdnd.nl/" class="home">Bekijk het programma</a>
-    </header>
+<header> 
+	    <img class="header-logo-hva" src="../hva-blank.svg" alt="naar de homepagina" height="50">
+	    <img class="header-logo" src="../fdnd.png" alt="FDND" width="100" height="50" style="object-fit: contain;">
+	    <a href="https://programma.fdnd.nl/" class="home">Bekijk programma</a>
+</header>
 
 {@render children?.()}
 
 <footer>
-        <img class="header-logo" src="../hva-blank.svg" alt="naar de homepagina" height="50">
+    <img class="header-logo" src="../hva-blank.svg" alt="naar de homepagina" height="50">
     <h2>Creating Tomorrow</h2>
 	<p>Amber, Stella & Julia | FDND 2025/2026</p>
 </footer>
-</main>
 
 <style>
 	* {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -111,18 +111,24 @@
         /* Padding */
         --padding-small: 1rem .5rem; 
         --padding-medium: 1rem 2rem; 
-        --padding-large: 3rem 2rem;
+        --padding-large: 7rem 10rem;
 
         background-color: var(--secondary-background);
         border-radius: var(--b-radius-large);
-        padding: var(--padding-large);
 
         font-family: var(--primary-font), sans-serif;
         font-size: 16px;
         color: var(--primary-text);
-
-        max-width: 1000px;
+        
         margin: 0 auto;
+    }
+
+    main {
+        padding: 5em 2em;
+
+        @media screen and (min-width: 800px) {
+            padding: var(--padding-large);
+        }
     }
 
     h3 {
@@ -241,6 +247,7 @@
         display: grid;
         grid-template-columns: repeat(auto-fill, minmax(15em, 1fr));
         gap: 2rem;
+        justify-items: center
     }
 
     article {

--- a/src/routes/[id]/+page.svelte
+++ b/src/routes/[id]/+page.svelte
@@ -51,20 +51,24 @@
     main {
         display: flex;
         flex-direction: column;
-        height: 100vh;
         gap: 2em;
         align-items: left;
-        padding: 2em 1em;
+        padding: 6em 2em 3em 2em;
         background-color: var(--secondary-color);
         position: relative;
         border-radius: 1em;
 
         @media screen and (min-width: 800px) {
+            height: 100vh;
             flex-direction: row;
-            padding: 2em 9em;
+            padding: 2em 10em;
             justify-content: center;
-             gap: 10em;
-              align-items: center;
+            gap: 2em;
+            align-items: center;
+        }
+
+        @media screen and (min-width: 1000px) {
+            gap: 3em;
         }
     }
 
@@ -157,7 +161,13 @@
 
         @media screen and (min-width: 800px) {
             width: 25em;
-            min-width: 22em;
+            max-width: 15em;
+        }
+
+        @media screen and (min-width: 1000px) {
+            width: 25em;
+            min-width: 20em;
+            max-width: 15em;
         }
     }
 
@@ -174,6 +184,11 @@
         border-radius: 0.4em;
 
         @media screen and (min-width: 800px) {
+            height: 15.5em;
+            width: 100%;
+        }
+
+        @media screen and (min-width: 1-00px) {
             height: 18.5em;
             width: 100%;
         }

--- a/src/routes/class/[class]/+page.svelte
+++ b/src/routes/class/[class]/+page.svelte
@@ -117,19 +117,25 @@
       /* Padding */
       --padding-small: 1rem .5rem; 
       --padding-medium: 1rem 2rem; 
-      --padding-large: 3rem 2rem;
+      --padding-large: 7rem 10rem;
 
       background-color: var(--secondary-background);
       border-radius: var(--b-radius-large);
-      padding: var(--padding-large);
 
       font-family: var(--primary-font), sans-serif;
       font-size: 16px;
       color: var(--primary-text);
 
-      max-width: 1000px;
       margin: 0 auto;
   }
+
+  main {
+        padding: 5em 2em;
+
+        @media screen and (min-width: 800px) {
+            padding: var(--padding-large);
+        }
+    }
 
   /* Reset */
   h1 {


### PR DESCRIPTION
## Wat heb ik gedaan?

In issue #84 ben ik aan de slag gegaan met het responsive maken van de header en footer. Ook heb ik de witte rand om de paarse border weggehaald en heb ik de border radius toegevoegd zoals in het Figma ontwerp.

### Veranderd:

- Header responsive gemaakt
- Footer responsive gemaakt
- Dubbele main weggehaald. (Er is nu 1 main op elke pagina omdat iedereen het anders gestyled heeft)
- Border radius toegevoegd op paarse border layout

### Waar wil ik feedback op?

- Wat vinden jullie nu van de layout? Is het responsive genoeg (zie visuals)?
- Wat vinden jullie van de header? Op scroll gaat de bovenste paarse border weg. Dit is voor nu het makkelijkst omdat we anders de hele semantiek van de header moeten omgooien.

## Visuals

#### (Helaas kan ik geen video's uploaden die zijn te zwaar en doen vervelend)

### Overzichtspagina

#### Desktop
<img width="1470" height="795" alt="image" src="https://github.com/user-attachments/assets/6b0e411d-fa38-4d0e-8c36-de829d33a315" />
<img width="1470" height="800" alt="image" src="https://github.com/user-attachments/assets/034c60b3-713d-4edc-96b3-adcf797adcf4" />


#### Mobile
<img width="300" alt="image" src="https://github.com/user-attachments/assets/03340d33-5d8b-4f61-901d-ab9bdd034b25" />


### detailpagina

#### Desktop
<img width="1470" height="785" alt="image" src="https://github.com/user-attachments/assets/0996b6d5-3a47-4a58-970b-e12ae56b8b6d" />

#### Mobile
<img width="300" alt="image" src="https://github.com/user-attachments/assets/f8d5b9c5-72a9-4d2c-9b56-51e6d7d96d89" />

<img width="300" alt="image" src="https://github.com/user-attachments/assets/b0b4a311-b091-41be-81b0-56927d6cface" />

